### PR TITLE
remove php warning

### DIFF
--- a/src/Definition/Grid.php
+++ b/src/Definition/Grid.php
@@ -165,11 +165,13 @@ class Grid
     public function buildColumn(int $index, bool $flat = false)
     {
         $classes = [];
-        foreach ($this->columns as $size => $columns) {
-            $column = $this->getColumnByIndex($columns, $index);
+        if(is_array($this->columns)) {
+            foreach ($this->columns as $size => $columns) {
+                $column = $this->getColumnByIndex($columns, $index);
 
-            if ($column) {
-                $classes = $column->build($classes, $size);
+                if ($column) {
+                    $classes = $column->build($classes, $size);
+                }
             }
         }
 


### PR DESCRIPTION
Remove php warning if I placed a grid start and grid stop element. I wanted only a div with the class row. The php warning was "PHP Warning: Invalid argument supplied for foreach()".