### PR TITLE
Unterstützung für Größensuffixe bei Alignments

### DIFF
--- a/src/Definition/Column.php
+++ b/src/Definition/Column.php
@@ -176,8 +176,8 @@ class Column
             $classes[] = 'd-none';
         }
 
-        $this->buildAlign($classes);
-        $this->buildJustify($classes);
+        $this->buildAlign($classes, $sizeSuffix);
+        $this->buildJustify($classes, $sizeSuffix);
         $this->buildOrder($classes, $sizeSuffix);
         $this->buildOffset($classes, $sizeSuffix);
 
@@ -219,13 +219,14 @@ class Column
      * Build the align setting.
      *
      * @param array $classes Column classes.
+     * @param string $sizeSuffix Bootstrap Size suffix like 'md' or 'lg'.
      *
      * @return void
      */
-    private function buildAlign(array &$classes): void
+    private function buildAlign(array &$classes, string $sizeSuffix = ''): void
     {
         if ($this->align) {
-            $classes[] = 'align-self-' . $this->align;
+            $classes[] = 'align-self'. $sizeSuffix . '-' . $this->align;
         }
     }
 
@@ -233,13 +234,14 @@ class Column
      * Build the justify setting.
      *
      * @param array $classes Column classes.
+     * @param string $sizeSuffix Bootstrap Size suffix like 'md' or 'lg'.
      *
      * @return void
      */
-    private function buildJustify(array &$classes): void
+    private function buildJustify(array &$classes, string $sizeSuffix = ''): void
     {
         if ($this->justify) {
-            $classes[] = 'justify-content-' . $this->justify;
+            $classes[] = 'justify-content' . $sizeSuffix . '-' . $this->justify;
         }
     }
 

--- a/src/Definition/Column.php
+++ b/src/Definition/Column.php
@@ -6,6 +6,7 @@
  * @package    contao-bootstrap
  * @subpackage Grid
  * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     Florian Vick <florian@florian-vick.de>
  * @copyright  2017 netzmacht David Molineus. All rights reserved.
  * @license    https://github.com/contao-bootstrap/grid/blob/master/LICENSE LGPL 3.0
  * @filesource
@@ -184,7 +185,7 @@ class Column
         if ($this->cssClasses) {
             $classes = array_merge($classes, $this->cssClasses);
         }
-        
+
         return array_unique($classes);
     }
 
@@ -218,7 +219,7 @@ class Column
     /**
      * Build the align setting.
      *
-     * @param array $classes Column classes.
+     * @param array  $classes    Column classes.
      * @param string $sizeSuffix Bootstrap Size suffix like 'md' or 'lg'.
      *
      * @return void
@@ -233,7 +234,7 @@ class Column
     /**
      * Build the justify setting.
      *
-     * @param array $classes Column classes.
+     * @param array  $classes    Column classes.
      * @param string $sizeSuffix Bootstrap Size suffix like 'md' or 'lg'.
      *
      * @return void


### PR DESCRIPTION
Im Backend kann man bei '_Gridgrößen und -spalten_' bei jeder Größe '_Vertikale Ausrichtung_' auswählen.
Bei der Ausgabe wird dies jedoch nicht berücksichtigt, es wird für alle Größen immer nur mehrfach zum Beispiel `align-self-end` anstatt `align-self-xx-end` ausgegeben.

Ich habe die entsprechenden Funktionen ergänzt, sodass nun die Größen wie md, lg usw. richtig ausgegeben werden sofern sie vorhanden sind.

Vorher:
`ce_bs_gridSeparator col-12 align-self-center col-lg-6 align-self-end`
Nachher:
`ce_bs_gridSeparator col-12 align-self-center col-lg-6 align-self-lg-end`