### PR TITLE
Do not migrate tl_bs_grid if it does not exist

### DIFF
--- a/src/Migration/MigrateAutoGridWidths.php
+++ b/src/Migration/MigrateAutoGridWidths.php
@@ -53,6 +53,12 @@ final class MigrateAutoGridWidths
      */
     public function __invoke(): void
     {
+        $schemaManager = $this->connection->getSchemaManager();
+
+        if (!$schemaManager->tablesExist(['tl_bs_grid'])) {
+            return;
+        }
+
         $statement = $this->connection->executeQuery('SELECT * FROM tl_bs_grid');
 
         while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {


### PR DESCRIPTION
When creating a fresh Contao installation including this extension and then running `contao:migrate`, the following error will occur:

```
[Doctrine\DBAL\Driver\PDO\Exception (42S02)]
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'eiseinfalt.tl_bs_grid' doesn't exist  


Exception trace:
  at vendor\doctrine\dbal\lib\Doctrine\DBAL\Driver\PDO\Exception.php:18
 Doctrine\DBAL\Driver\PDO\Exception::new() at vendor\doctrine\dbal\lib\Doctrine\DBAL\Driver\PDOConnection.php:143
 Doctrine\DBAL\Driver\PDOConnection->doQuery() at vendor\doctrine\dbal\lib\Doctrine\DBAL\Driver\PDOQueryImplementation.php:38
 Doctrine\DBAL\Driver\PDOConnection->query() at vendor\doctrine\dbal\lib\Doctrine\DBAL\Connection.php:1309
 Doctrine\DBAL\Connection->executeQuery() at vendor\contao-bootstrap\grid\src\Migration\MigrateAutoGridWidths.php:56
 ContaoBootstrap\Grid\Migration\MigrateAutoGridWidths->__invoke() at vendor\contao-bootstrap\grid\src\Resources\contao\config\runonce.php:17 
 Contao\CoreBundle\Command\MigrateCommand->{closure}() at vendor\contao-bootstrap\grid\src\Resources\contao\config\runonce.php:18
 include() at vendor\contao\core-bundle\src\Command\MigrateCommand.php:275
 Contao\CoreBundle\Command\MigrateCommand->executeRunonceFile() at vendor\contao\core-bundle\src\Command\MigrateCommand.php:235
 Contao\CoreBundle\Command\MigrateCommand->executeMigrations() at vendor\contao\core-bundle\src\Command\MigrateCommand.php:138
 Contao\CoreBundle\Command\MigrateCommand->executeCommand() at vendor\contao\core-bundle\src\Command\MigrateCommand.php:91
 Contao\CoreBundle\Command\MigrateCommand->execute() at vendor\symfony\console\Command\Command.php:255
 Symfony\Component\Console\Command\Command->run() at vendor\symfony\console\Application.php:1027
 Symfony\Component\Console\Application->doRunCommand() at vendor\symfony\framework-bundle\Console\Application.php:97
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at vendor\symfony\console\Application.php:273
 Symfony\Component\Console\Application->doRun() at vendor\symfony\framework-bundle\Console\Application.php:83
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at vendor\symfony\console\Application.php:149
 Symfony\Component\Console\Application->run() at vendor\contao\manager-bundle\bin\contao-console:37
 include() at vendor\bin\contao-console:112
```

This PR fixes that by checking whether the table is actually present.