### PR TITLE
Remove superfluous space in separator template

### DIFF
--- a/src/Resources/contao/templates/elements/ce_bs_gridSeparator.html5
+++ b/src/Resources/contao/templates/elements/ce_bs_gridSeparator.html5
@@ -2,4 +2,4 @@
     <?php foreach ($this->resets as $reset): ?>
     <div class="clearfix w-100 <?= $reset ?>"></div>
     <?php endforeach; ?>
-    <div <?= $this->cssID; ?> class="<?= $this->class ?> <?= $this->columnClasses ?>">
+    <div<?= $this->cssID; ?> class="<?= $this->class ?> <?= $this->columnClasses ?>">


### PR DESCRIPTION
Currently the CSS ID of a grid separator will always be output with two spaces between the tag name and the ID attribute, as the `cssID` variable already includes a space. This is correct in the other templates, but the adjustment is still missing from the separator template. This PR fixes that by removing the space preceding the output of the `cssID` variable.